### PR TITLE
Make the spinner example really spin like a spinner should.

### DIFF
--- a/examples/tests/spinner.py
+++ b/examples/tests/spinner.py
@@ -3,7 +3,7 @@
 import time
 import fourletterphat as flp
 
-spinner = ["|", "/", "-", "/"]
+spinner = ["|", "/", "-", "\\"]
 
 while True:
     for i in range(4):


### PR DESCRIPTION
Replacing the last step of the spinning from "/" to "\\".