### PR TITLE
Defer setup to avoid module import-time side-effects

### DIFF
--- a/library/fourletterphat/__init__.py
+++ b/library/fourletterphat/__init__.py
@@ -6,27 +6,164 @@ from .HT16K33 import *
 
 __version__ = '0.0.2'
 
-display = AlphaNum4(i2c=bus)
-display.begin()
-display.clear()
-display.show()
 
-set_blink = display.set_blink
-set_brightness = display.set_brightness
-set_digit_raw = display.set_digit_raw
-set_decimal = display.set_decimal
-set_digit = display.set_digit
-print_str = display.print_str
-print_number_str = display.print_number_str
-print_float = display.print_float
-print_hex = display.print_hex
-show = display.show
-clear = display.clear
-glow = display.glow
-scroll_print = display.scroll_print
+display = None
+
+_is_setup = False
+
 
 def _exit():
     display.clear()
     display.show()
 
-atexit.register(_exit)
+def set_blink(frequency):
+    """Blink display at specified frequency.
+
+    Note that frequency must be a value allowed by the HT16K33, specifically one of:
+
+     * HT16K33_BLINK_OFF,
+     * HT16K33_BLINK_2HZ,
+     * HT16K33_BLINK_1HZ, or
+     * HT16K33_BLINK_HALFHZ.
+
+    """
+
+    setup()
+    display.set_blink(frequency)
+
+def set_brightness(brightness):
+    """Set brightness of entire display to specified value.
+
+    Supports 16 levels, from 0 to 15.
+
+    """
+
+    setup()
+    display.set_brightness(brightness)
+
+def set_digit_raw(pos, bitmask):
+    """Set digit at position to raw bitmask value.
+
+    Position should be a value of 0 to 3 with 0 being the left most digit on the display.
+
+    """
+
+    setup()
+    display.set_digit_raw(pos, bitmask)
+
+def set_decimal(pos, decimal):
+    """Turn decimal point on or off at provided position.
+
+    Position should be a value 0 to 3 with 0 being the left most digit on the display.
+    Decimal should be True to turn on the decimal point and False to turn it off.
+
+    """
+
+    setup()
+    display.set_decimal(pos, decimal)
+
+def set_digit(pos, digit, decimal=False):
+    """Set digit at position to provided value.
+
+    Position should be a value of 0 to 3 with 0 being the left most digit on the display.
+    Digit should be any ASCII value 32-127 (printable ASCII).
+
+    """
+
+    setup()
+    display.set_digit(pos, digit, decimal)
+
+def print_str(value, justify_right=True):
+    """Print a 4 character long string of values to the display.
+
+    Characters in the string should be any ASCII value 32 to 127 (printable ASCII).
+
+    """
+
+    setup()
+    display.print_str(value, justify_right)
+
+def print_number_str(value, justify_right=True):
+    """Print a 4 character long string of numeric values to the display.
+
+    This function is similar to print_str but will interpret periods not as
+    characters but as decimal points associated with the previous character.
+
+    """
+
+    setup()
+    display.print_number_str(value, justify_right=True)
+
+def print_float(value, decimal_digits=2, justify_right=True):
+    """Print a numeric value to the display.
+
+    If value is negative it will be printed with a leading minus sign.
+    Decimal digits is the desired number of digits after the decimal point.
+
+    """
+
+    setup()
+    display.print_float(value, decimal_digits, justify_right)
+
+def print_hex(value, justify_right=True):
+    """Print a numeric value in hexadecimal.
+
+    Value should be from 0 to FFFF.
+
+    """
+
+    setup()
+    display.print_hex(value, justify_right)
+
+def show():
+    """Display buffer on display."""
+
+    setup()
+    display.show()
+
+def clear():
+    setup()
+    display.clear()
+
+def glow(period=4, duration=4):
+    """Cycles display brightness from low to high and back to low,
+    at a frequency of 1/period Hz and for a duration stated in seconds.
+
+    The periodicity accounts from initial brightness back to initial brightness.
+
+    :param period: Period of glow effect in seconds. (default 4 for 0.25Hz)
+    :param duration: Duration of glow effect in seconds. Function returns after duration seconds (default 4 seconds)
+
+    """
+
+    setup()
+    display.glow(period, duration)
+
+def scroll_print(s, tempo=0.3):
+    """Scrolls a string on the display.
+
+       :param tempo: Display is paused 3xtempo seconds at the start,
+         then tempo seconds after each one character scroll, then 3xtempo seconds at the end. (default 0.3 seconds)
+
+    """
+
+    setup()
+    display.scroll_print(s, tempo)
+
+def setup():
+    """Set up the display."""
+
+    global _is_setup, display
+
+    if _is_setup:
+        return True
+
+    display = AlphaNum4(i2c=bus)
+    display.begin()
+    display.clear()
+    display.show()
+
+    atexit.register(_exit)
+
+    _is_setup = True
+

--- a/library/fourletterphat/i2c_bus.py
+++ b/library/fourletterphat/i2c_bus.py
@@ -4,9 +4,9 @@ try:
     import smbus
 except ImportError:
     if version_info[0] < 3:
-        exit("This library requires python-smbus\nInstall with: sudo apt-get install python-smbus")
+        raise ImportError("This library requires python-smbus\nInstall with: sudo apt-get install python-smbus")
     elif version_info[0] == 3:
-        exit("This library requires python3-smbus\nInstall with: sudo apt-get install python3-smbus")
+        raise ImportError("This library requires python3-smbus\nInstall with: sudo apt-get install python3-smbus")
 
 bus = smbus.SMBus(1)
 


### PR DESCRIPTION
This PR makes several "friendly neighbour" changes to the Four Letter pHAT library to avoid code being unnecessarily executed upon import.

See here for details of the problems import-time side-effects can have: https://www.raspberrypi.org/forums/viewtopic.php?f=32&t=193502&p=1212488#p1212488