### PR TITLE
Update __init__.py

### DIFF
--- a/library/fourletterphat/__init__.py
+++ b/library/fourletterphat/__init__.py
@@ -11,10 +11,23 @@ display = None
 
 _is_setup = False
 
+_clear_on_exit = True
 
 def _exit():
-    display.clear()
-    display.show()
+    if _clear_on_exit:
+        display.clear()
+        display.show()
+    
+def set_clear_on_exit():
+    """Toggle the clear on exit flag.
+
+    Default value will clear the display on exit.
+
+    """
+
+    global _clear_on_exit
+
+    _clear_on_exit = not _clear_on_exit
 
 def set_blink(frequency):
     """Blink display at specified frequency.


### PR DESCRIPTION
Added support to toggle clearing the display on exit using a new global variable _clear_on_exit. If the toggle is set to True (default), then the display will clear as it did previously. If the toggle is set to False, the display will not clear at exit. This allows the display to stay on after code execution.

Calling set_clear_on_exit() will toggle the _clear_on_exit global.